### PR TITLE
Fix popup redirect

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+# Web-ext build artifacts
+web-ext-artifacts/
+
+# Other common items you might want:
+node_modules/
+*.log
+.DS_Store

--- a/js/background/newTab.js
+++ b/js/background/newTab.js
@@ -14,10 +14,26 @@ const newTab = {
     // Checking the URL alone should be enough but keeping the openerTabId check should not cause issues.
     //
     // Added check for pop-up to not redirect back to homepage
+    console.log("Checking tab:", {
+      id: tab.id,
+      windowId: tab.windowId,
+      openerTabId: tab.openerTabId,
+      url: tab.url,
+      title: tab.title,
+    });
+
+    // check if this tab is in a popup window
     if (tab.windowId) {
       try {
         const window = await browser.windows.get(tab.windowId);
+        console.log("Window info:", {
+          type: window.type,
+          id: window.id,
+          state: window.state,
+        });
+
         if (window.type === "popup") {
+          console.log("Detected popup - not redirecting");
           return false;
         }
       } catch (e) {
@@ -28,20 +44,50 @@ const newTab = {
       tab.openerTabId === undefined &&
       (tab.url === "about:newtab" || tab.url === "about:blank") &&
       tab.title === "New Tab";
+
+    console.log("isNew result:", isNew);
     return isNew;
   },
   async onCreated(tab) {
+    console.log("Tab created event fired for tab:", tab.id);
+
     if (await newTab.isNewTab(tab)) {
-      try {
-        const defaultUrl = await containerDefaultPages.getDefaultPage(
-          tab.cookieStoreId,
-        );
-        if (defaultUrl) {
-          browser.tabs.update(tab.tabId, { url: defaultUrl });
+      console.log("Initial check passed - waiting to see if URL changes...");
+
+      // Wait to see if the URL changes (indicating it's not a real new tab)
+      setTimeout(async () => {
+        try {
+          const updatedTab = await browser.tabs.get(tab.id);
+          console.log("Tab after delay:", {
+            url: updatedTab.url,
+            title: updatedTab.title,
+            status: updatedTab.status,
+          });
+
+          // If URL is still about:newtab or about:blank, it's likely a real new tab
+          if (
+            updatedTab.url === "about:newtab" ||
+            updatedTab.url === "about:blank"
+          ) {
+            console.log(
+              "Still blank after delay - redirecting to default page",
+            );
+            const defaultUrl = await containerDefaultPages.getDefaultPage(
+              updatedTab.cookieStoreId,
+            );
+            if (defaultUrl) {
+              console.log("Redirecting to:", defaultUrl);
+              browser.tabs.update(updatedTab.id, { url: defaultUrl });
+            }
+          } else {
+            console.log("URL changed to real content - not redirecting");
+          }
+        } catch (e) {
+          console.log("Error in delayed check:", e);
         }
-      } catch (e) {
-        console.log(e);
-      }
+      }, 300); // Try 300ms to give popup time to load
+    } else {
+      console.log("Initial check failed - not redirecting");
     }
   },
   init() {

--- a/js/background/newTab.js
+++ b/js/background/newTab.js
@@ -1,37 +1,52 @@
-
-
 const newTab = {
-  isNewTab(tab){
+  async isNewTab(tab) {
     // checking openerTabId this way prevents loading default url to links that are directed to new tabs
-    // such as "Open in New Tab". Otherwise, checking only the tab title and url is not enough as both 
+    // such as "Open in New Tab". Otherwise, checking only the tab title and url is not enough as both
     // will keep updating while the tab status changes from "loading" to "complete".
     // https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/tabs/onCreated
     // We could wait for the tab to finish loading and check the title and the url but that's time wasted.
-    // There yet to exist a legitimate case where checking openerTabId does not work. 
+    // There yet to exist a legitimate case where checking openerTabId does not work.
     // known issue: this won't work in case of opening "about:newtab" link as "Open in New Tab"
     // but arguably that's not a real use case.
 
     // this used to only check the openerTabId and worked for most cases, but caused a conflict with the MAC ext. issue #1
-    // so checking the URL and title were added, which requires the tab permission. 
+    // so checking the URL and title were added, which requires the tab permission.
     // Checking the URL alone should be enough but keeping the openerTabId check should not cause issues.
-    let isNew = tab.openerTabId === undefined && (tab.url === "about:newtab" || tab.url === "about:blank") && tab.title === "New Tab";
+    //
+    // Added check for pop-up to not redirect back to homepage
+    if (tab.windowId) {
+      try {
+        const window = await browser.windows.get(tab.windowId);
+        if (window.type === "popup") {
+          return false;
+        }
+      } catch (e) {
+        console.log("Error checking window type: ", e);
+      }
+    }
+    let isNew =
+      tab.openerTabId === undefined &&
+      (tab.url === "about:newtab" || tab.url === "about:blank") &&
+      tab.title === "New Tab";
     return isNew;
   },
-  async onCreated(tab){
-    if (newTab.isNewTab(tab)){
-      try{
-        const defaultUrl = await containerDefaultPages.getDefaultPage(tab.cookieStoreId)
-        if(defaultUrl){
-          browser.tabs.update(tab.tabId, {url: defaultUrl});
+  async onCreated(tab) {
+    if (await newTab.isNewTab(tab)) {
+      try {
+        const defaultUrl = await containerDefaultPages.getDefaultPage(
+          tab.cookieStoreId,
+        );
+        if (defaultUrl) {
+          browser.tabs.update(tab.tabId, { url: defaultUrl });
         }
-      }catch(e){
-        console.log(e)
+      } catch (e) {
+        console.log(e);
       }
     }
   },
-  init(){
+  init() {
     browser.tabs.onCreated.addListener(this.onCreated);
   },
-}
+};
 
-newTab.init()
+newTab.init();

--- a/js/background/newTab.js
+++ b/js/background/newTab.js
@@ -14,23 +14,11 @@ const newTab = {
     // Checking the URL alone should be enough but keeping the openerTabId check should not cause issues.
     //
     // Added check for pop-up to not redirect back to homepage
-    console.log("Checking tab:", {
-      id: tab.id,
-      windowId: tab.windowId,
-      openerTabId: tab.openerTabId,
-      url: tab.url,
-      title: tab.title,
-    });
 
     // check if this tab is in a popup window
     if (tab.windowId) {
       try {
         const window = await browser.windows.get(tab.windowId);
-        console.log("Window info:", {
-          type: window.type,
-          id: window.id,
-          state: window.state,
-        });
 
         if (window.type === "popup") {
           console.log("Detected popup - not redirecting");
@@ -45,49 +33,31 @@ const newTab = {
       (tab.url === "about:newtab" || tab.url === "about:blank") &&
       tab.title === "New Tab";
 
-    console.log("isNew result:", isNew);
     return isNew;
   },
   async onCreated(tab) {
-    console.log("Tab created event fired for tab:", tab.id);
-
     if (await newTab.isNewTab(tab)) {
-      console.log("Initial check passed - waiting to see if URL changes...");
-
       // Wait to see if the URL changes (indicating it's not a real new tab)
       setTimeout(async () => {
         try {
           const updatedTab = await browser.tabs.get(tab.id);
-          console.log("Tab after delay:", {
-            url: updatedTab.url,
-            title: updatedTab.title,
-            status: updatedTab.status,
-          });
 
           // If URL is still about:newtab or about:blank, it's likely a real new tab
           if (
             updatedTab.url === "about:newtab" ||
             updatedTab.url === "about:blank"
           ) {
-            console.log(
-              "Still blank after delay - redirecting to default page",
-            );
             const defaultUrl = await containerDefaultPages.getDefaultPage(
               updatedTab.cookieStoreId,
             );
             if (defaultUrl) {
-              console.log("Redirecting to:", defaultUrl);
               browser.tabs.update(updatedTab.id, { url: defaultUrl });
             }
-          } else {
-            console.log("URL changed to real content - not redirecting");
           }
         } catch (e) {
           console.log("Error in delayed check:", e);
         }
-      }, 300); // Try 300ms to give popup time to load
-    } else {
-      console.log("Initial check failed - not redirecting");
+      }, 100); // timeout to give pop-ups time to load url
     }
   },
   init() {

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Container Home Pages",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "manifest_version": 2,
   "incognito": "not_allowed",
   "description": "Specify a default page for each container.",
@@ -9,12 +9,7 @@
     "page": "options.html",
     "browser_style": true
   },
-  "permissions": [
-    "contextualIdentities",
-    "storage",
-    "cookies",
-    "tabs"
-  ],
+  "permissions": ["contextualIdentities", "storage", "cookies", "tabs"],
   "background": {
     "page": "js/background/index.html"
   },
@@ -25,6 +20,6 @@
     }
   },
   "icons": {
-		"1024": "img/logo.png"
-	}
+    "1024": "img/logo.png"
+  }
 }


### PR DESCRIPTION
Fixes an issue where some pop-ups through pages like outlook web get redirected to the container homepage. This PR adds a check for a preexisting URL first before determining that a new tab is actually a new tab.